### PR TITLE
Fix active_tick_index assertion

### DIFF
--- a/src/quoting/base_pool.rs
+++ b/src/quoting/base_pool.rs
@@ -83,17 +83,11 @@ impl BasePool {
             );
         } else {
             if let Some(first) = sorted_ticks.first() {
-                if state.sqrt_ratio
-                    > to_sqrt_ratio(first.index).expect("first tick has invalid index")
-                {
-                    if let Some(last) = sorted_ticks.last() {
-                        assert!(
-                            state.sqrt_ratio
-                                >= to_sqrt_ratio(last.index).expect("last tick has invalid index"),
-                            "tick must be outside first and last tick if active_tick_index is none"
-                        );
-                    }
-                }
+                assert!(
+                    state.sqrt_ratio
+                        <= to_sqrt_ratio(first.index).expect("first tick has invalid index"),
+                    "current sqrt_ratio must be lower than equal sqrt_ratio of first tick if active_tick_index is none"
+                );
             }
         }
 


### PR DESCRIPTION
An `active_tick_index` of `None` should represent a state where the current tick is uninitialized and its sqrt_ratio being lower than that of any other initialized ticks.
Previously, the assertion also allowed uninitialized ticks with sqrt_ratios higher than that of any other initialized ticks to be represented by `None`, but the quoting function doesn't work with this assumption.